### PR TITLE
[WIP]新規登録３つ目のお届け先住所入力画面マークアップ

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,3 +19,4 @@
 @import "shared/main_aside";
 @import "items/confirmation";
 @import "signup/phone";
+@import "signup/address";

--- a/app/assets/stylesheets/signup/_address.scss
+++ b/app/assets/stylesheets/signup/_address.scss
@@ -1,0 +1,251 @@
+.common-container{
+  .common-header{
+    h1{
+      display: inline-block;
+      margin: 11px 0 12px;
+    }
+    //現在ページ情報のバー
+    .progress-bar{
+      font-size: 0;
+      text-align: center;
+    }
+    .signup-bar.progress-bar{
+      padding: 16px 0;
+      border-top: 1px solid #eee;
+      ol{
+        margin: 0;
+        li{
+          position: relative;
+          z-index: 1;
+          display: inline-block;
+          min-width: 40px;
+          margin: 0 5% 0 0;
+          font-size: 12px;
+          color: #888;
+          .progress-status{
+            width: 12px;
+            height: 12px;
+            margin: 8px auto 0;
+            background: #ccc;
+            border-radius: 50%;
+          }
+          .progress-status:before{
+            position: absolute;
+            bottom: 5px;
+            z-index: -1;
+            display: block;
+            content: '';
+            width: 100%;
+            height: 2px;
+            background: #ccc;
+            right: 50%;
+          }
+          .progress-status:after{
+            position: absolute;
+            bottom: 5px;
+            z-index: -1;
+            display: block;
+            content: '';
+            width: 100%;
+            height: 2px;
+            background: #ccc;
+            position: absolute;
+            left: 50%;
+          }
+        }
+        li.through{
+          .progress-status{
+            background: #ea352d;
+          }
+          .progress-status:before{
+            background: #ea352d;
+          }
+          .progress-status:after{
+            background: #ea352d;
+          }
+        }
+        li.active_red{
+          font-weight: 600;
+          color: #ea352d;
+          .progress-status{
+            background: #ea352d;
+          }
+          .progress-status{
+            background: #ea352d;
+          }
+          .progress-status:before{
+            background: #ea352d;
+          }
+          .progress-status:after{
+            background: #ccc;
+          }
+        }
+        li:first-child{
+          .progress-status:before{
+            background: none;
+          }
+        }
+        li:last-child{
+          .progress-status:after{
+            background: none;
+          }
+        }
+      }
+    }
+  }
+  .contents__form__require{
+    margin: 0 0 0 8px;
+    padding: 2px 4px;
+    background: #ea352d;
+    border-radius: 2px;
+    color: #fff;
+    font-size: 12px;
+    vertical-align: top;
+  }
+  .input-default{
+    width: 100%;
+    height: 48px;
+    padding: 10px 16px 8px;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+    background: #fff;
+    line-height: 1.5;
+    font-size: 16px;
+    margin: 8px 0 0;
+  }
+  .contents__form__arbitrary{
+    background: #ccc;
+    color: #fff;
+    margin: 0 0 0 8px;
+    padding: 2px 4px;
+    border-radius: 2px;
+    font-size: 12px;
+    vertical-align: top;
+
+  }
+  main{
+    display: block;
+    .l-step3-content{
+      width: 100%;
+      .l-chapter-container{
+        background: #fff;
+        margin: 0;
+        h2{
+          padding: 12px 4%;
+          text-align: center;
+          font-size: 18px;
+          border-bottom: 1px solid #f5f5f5;
+        }
+        form{
+          padding: 24px 16px 40px;
+
+        }
+        .l-step3-inner{
+          border-top: 1px solid #f5f5f5;
+
+        }
+        .l-step3-content{
+          max-width: 343px;
+          margin: 0 auto;
+          .form-group:first-child{
+            margin: 0;
+          }
+          .form-group{
+            margin: 24px 0 0;
+            label{
+              font-weight: 600;
+              display: inline-block;
+            }
+            .select-wrap{
+              margin: 8px 0 0;
+              position: relative;
+              select{
+                position: relative;
+                z-index: 2;
+                height: 48px;
+                width: 100%;
+                padding: 0 16px;
+                border: 1px solid #ccc;
+                border-radius: 4px;
+                background: #fff;
+                font-size: 16px;
+                line-height: 1.5;
+                cursor: pointer;
+
+              }
+            }
+          }
+          .btn-red{
+            margin: 24px 0 0;
+            background: #ea352d;
+            border: 1px solid #ea352d;
+            color: #fff;
+          }
+        }
+      }
+    }
+  }
+}
+@media screen and (min-width: 768px){
+.common-container{
+  .common-header{
+    height: 128px;
+    h1{
+      margin: 40px 0 0;
+      a{
+        width: 185px;
+        height: 49px;
+        line-height: 49px;
+        img{
+          width: 185px;
+          height: 49px;
+        }
+      }
+    }
+    .signup-bar.progress-bar{
+      padding: 40px 0 0 44px;
+      border: 0;
+      ol{
+        li{
+          margin: 0 40px 0 0;
+          min-width: 60px;
+        }
+        li:last-child{
+          margin: 0;
+        }  
+      }
+    }  
+    .progress-bar{
+      display: inline-block;
+      vertical-align: top;
+    }
+  }
+  .l-step3-container{
+    width: 700px;
+    margin: 24px auto 0;
+    .l-step3-content{
+      float: none;
+      width: 700px;
+      section{
+        .h2{
+          font-size: 24px;
+          padding: 8px 24px;    
+        }
+      }
+    }  
+  }
+  .common-footer{
+    width: 456px;
+    height: 220px;
+    margin: 0 auto;
+    nav{
+      ul{
+        li{
+          display: inline-block;
+          margin:0 0 0 16px;
+        }
+      }
+    }
+  }
+} 
+} 

--- a/app/assets/stylesheets/signup/_address.scss
+++ b/app/assets/stylesheets/signup/_address.scss
@@ -102,17 +102,6 @@
     font-size: 12px;
     vertical-align: top;
   }
-  .input-default{
-    width: 100%;
-    height: 48px;
-    padding: 10px 16px 8px;
-    border-radius: 4px;
-    border: 1px solid #ccc;
-    background: #fff;
-    line-height: 1.5;
-    font-size: 16px;
-    margin: 8px 0 0;
-  }
   .contents__form__arbitrary{
     background: #ccc;
     color: #fff;

--- a/app/assets/stylesheets/users/_login.scss
+++ b/app/assets/stylesheets/users/_login.scss
@@ -1,5 +1,5 @@
 .common-container{
-  .single-main{
+  .login-main{
     .login-panel{
       max-width: 456px;
       margin: 0 auto;
@@ -93,4 +93,48 @@
       }
     }
   }
+}
+@media screen and (min-width: 768px){
+.common-container{
+  .common-header{
+    height: 128px;
+    h1{
+      margin:40px 0 0;
+      a{
+        width: 180px;
+        height: 49px;
+        line-height: 49px;
+        img{
+          width: 180px;
+          height: 49px;
+        }
+      }
+    }
+  }
+  .singles-main{
+    .login-panel{
+      width: 456px;
+      max-width: none;
+      .login-no-account{
+        padding: 40px 64px;
+      }
+      .login-form-inner{
+        padding: 32px 64px;
+
+      }
+      form{
+        .login-form-inner:first-child{
+          padding: 24px 64px 32px;
+          .form-group{
+            div{
+              transform: none;
+
+            }
+          }
+        }
+      }
+    }
+  }
 } 
+}
+ 

--- a/app/assets/stylesheets/users/_login.scss
+++ b/app/assets/stylesheets/users/_login.scss
@@ -111,7 +111,7 @@
       }
     }
   }
-  .singles-main{
+  .login-main{
     .login-panel{
       width: 456px;
       max-width: none;

--- a/app/controllers/tests_controller.rb
+++ b/app/controllers/tests_controller.rb
@@ -11,4 +11,6 @@ class TestsController < ApplicationController
   def phone
   end
   
+  def address
+  end
 end

--- a/app/views/tests/address.html.haml
+++ b/app/views/tests/address.html.haml
@@ -48,7 +48,7 @@
               %span.contents__form__require 必須
               .select-wrap
                 = fa_icon "arrow-bottom"
-                = f.collection_select :prefecture_id, Prefecture.all, :id, :name, prompt: "",class: "select-default"
+                = f.collection_select :prefecture_id, Prefecture.all, :id, :name, prompt: "--",class: "select-default"
             .form-group
               %label 市区町村
               %span.contents__form__require 必須

--- a/app/views/tests/address.html.haml
+++ b/app/views/tests/address.html.haml
@@ -1,0 +1,71 @@
+.common-container
+  %header.common-header
+    = render 'shared/signup-header' 
+    -# active_redは赤丸表示、afterはactiveより後（右側）の線を定義、beforeはactiveより前（左側）
+    -# thoughはすでに入力完了したページ部分、赤丸表示とactive_redまでの横線を赤く表示
+    %nav.progress-bar.signup-bar
+      %ol.clearfix
+        %li.through
+          会員情報
+          .progress-status
+        %li.through
+          電話番号認証
+          .progress-status
+        %li.active_red
+          お届け先住所入力
+          .progress-status
+        %li
+          支払い方法
+          .progress-status
+        %li
+          完了
+          .progress-status
+  %main.l-step3-container.clearfix
+    .l-step3-content
+      %section.l-chapter-container
+        %h2.l-chapter-head
+          発送元・お届け先住所入力
+        = form_for "", url: "", method: :get, html: {class: 'l-step3-inner registration-form'} do |f|
+          .l-step3-inner
+            %input{type: "hidden", name: "csrf_value", value: ""}
+          .l-step3-content
+            .form-group
+              %label お名前
+              %span.contents__form__require 必須
+              %input{type: "text", name: "family_name", placeholder: "例）山田", class: "input-default"}
+              %input{type: "text", name: "first_name", placeholder: "例）彩", class: "input-default"}
+            .form-group
+              %label お名前カナ
+              %span.contents__form__require 必須
+              %input{type: "text", name: "family_name_kana", placeholder: "例）ヤマダ", class: "input-default"}
+              %input{type: "text", name: "first_name_kana", placeholder: "例）アヤ", class: "input-default"}
+            .form-group
+              %label 郵便番号
+              %span.contents__form__require 必須
+              %input{type: "text", name:"zip_code1", placeholder:"例) 123-4567", maxlength:"8",pattern:"\d{3}-\d{4}", class: "input-default"}
+            .form-group
+              %label 都道府県
+              %span.contents__form__require 必須
+              .select-wrap
+                = fa_icon "arrow-bottom"
+                = f.collection_select :prefecture_id, Prefecture.all, :id, :name, prompt: "",class: "select-default"
+            .form-group
+              %label 市区町村
+              %span.contents__form__require 必須
+              %input{type: "text", name: "city", placeholder: "例）横浜市緑区", class: "input-default"}
+            .form-group
+              %label 番地
+              %span.contents__form__require 必須
+              %input{type: "text", name: "address1", placeholder: "例）青山1-1-1", class: "input-default"}
+            .form-group
+              %label 建物名
+              %span.contents__form__arbitrary 任意
+              %input{type: "text", name: "address2", placeholder: "例) 柳ビル103", class: "input-default"}
+            .form-group
+              %label 電話
+              %span.contents__form__arbitrary 任意
+              %input{type: "number", name: "telephone", placeholder:"例) 09012345678", class: "input-default"}
+            %input{type: "hidden", name: ""}
+            %button{type: "submit", class: "btn-default btn-red"}
+              次へ進む
+  = render  "shared/signup-footer"

--- a/app/views/tests/login.html.haml
+++ b/app/views/tests/login.html.haml
@@ -1,7 +1,7 @@
 .common-container
   %header.common-header
     = render 'shared/signup-header'
-  %main.single-main
+  %main.login-main
     .login-panel
       .login-no-account
         %p

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   get 'login', to: 'tests#login'
   get 'phone', to: 'tests#phone'
   get 'registration', to: 'tests#registration'
+  get 'address', to: 'tests#address'
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
#What
新規登録３つ目の画面をhamlとscssで実装、またログインページのビュー崩れを修正
#Why
発送元と発送先住所の情報は出品した商品が購入された時に発送する際に必要な情報のため

お届け先住所画面
https://gyazo.com/a3fdbdd6baeb0d76925e18e82d08a2b2
https://gyazo.com/4da5b48203cae70e761cf21edd4e4ac9
ログインページ
https://gyazo.com/286640b05fd3be499593943b57f38d6e